### PR TITLE
Add scale to drumline processes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/openrelayxyz/drumline
+
+go 1.19


### PR DESCRIPTION
Drumline was originally created to keep different partitions on the same kafka topics in sync - to keep Go from processing a ton of one partition while ignoring others. For partitions on the same topic which should be distributed across with a uniform distribution, this worked quite well.

Later we tried to apply this to partitions across multiple different topics, but because the different topics receive different volumes of messages, things didn't really stay in sync with respect to publishing time.

I've tried several different experiments with ways to try and synchronize different topic / partition processing more precisely, but all ended up with very complex APIs that would require significant code rewrites for questionable benefits. This implementation is the first one that is backwards compatible API-wise, and requires only a small change to the code we're trying to synchronize to take advantage of the enhanced synchronization capability.

To take advantage of the new scaling approach, switch from using `Add(threadid)` to `AddScale(threadid, scale)`. `Add(threadid)` is now an alias for `AddScale(threadid, 1)`, so old code should be unimpacted by the update.

The `scale` values should be proportional to the number of messages each thread is expected to process relative to others. Drumline will normalize the scales across threads, so application code doesn't need to worry about that normalization, they just need to provide numbers that are proportional across each thread. For example, if synchronizing Kafka partitions across multiple topics, the application can provide the high watermark offset of the partition each thread is processing and drumline will scale to the frequency with which each partition receives messages.